### PR TITLE
Bump spring.version in /Chapter-10-Spring-MVC-pattern

### DIFF
--- a/Chapter-10-Spring-MVC-pattern/pom.xml
+++ b/Chapter-10-Spring-MVC-pattern/pom.xml
@@ -6,7 +6,7 @@
   <packaging>war</packaging>
   
    <properties>
-  	<spring.version>5.0.2.RELEASE</spring.version>
+  	<spring.version>5.2.3.RELEASE</spring.version>
   	<aspectj.version>1.8.9</aspectj.version>
   </properties>
   


### PR DESCRIPTION
Bumps `spring.version` from 5.0.2.RELEASE to 5.2.3.RELEASE.

Updates `spring-webmvc` from 5.0.2.RELEASE to 5.2.3.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.0.2.RELEASE...v5.2.3.RELEASE)

Updates `spring-orm` from 5.0.2.RELEASE to 5.2.3.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.0.2.RELEASE...v5.2.3.RELEASE)

Signed-off-by: dependabot[bot] <support@github.com>